### PR TITLE
refactor: simplify workflow dispatch, use github.sha directly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,6 @@ name: Deploy to GitHub Pages
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Git ref (tag, branch, or SHA) to deploy'
-        required: true
-        default: 'main'
-        type: string
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -33,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Remove redundant workflow_dispatch.inputs.ref input
- Use github.sha directly for checkout action

Now the workflow uses the same ref you trigger it from, no extra input needed.