### PR TITLE
ci: upgrade Node to v24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
Upgrade Node.js version from 22 to 24 in GitHub Actions workflow.