### PR TITLE
feat: add language toggle to mobile, /es redirect, and auto-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+# Automatic release when package.json version changes
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths: [package.json]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: justincy/github-action-npm-release@v1.2.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,38 @@
 - Always explain plan before executing changes
 - Wait for explicit "adelante" or approval before making edits
 - Never auto-commit or auto-push — user reviews changes first
+
+## Releases
+
+### Version bump
+Follow semver when updating `version` in `package.json`:
+- **Patch** (x.x.**1**) → bug fixes only
+- **Minor** (x.**1**.0) → new features, backward compatible
+- **Major** (**1**.x.x) → breaking changes
+
+### How it works
+The release workflow (`.github/workflows/release.yml`) triggers automatically when:
+1. Push to `main` branch
+2. `package.json` file has changed
+
+The workflow:
+- Reads the new version from `package.json`
+- Creates a git tag `v{x.y.z}`
+- Creates a GitHub Release with **auto-generated changelog** from PRs since last release
+
+### PR Labels
+For meaningful changelogs, add labels to PRs before merging:
+- `feat` → New features
+- `fix` → Bug fixes
+- `chore` → Maintenance
+- `refactor` → Code refactoring
+
+### Release Example
+```
+1. PR: "feat: add language toggle to mobile" → label: feat
+2. Merge PR to main
+3. Update version in package.json: 2.0.1 → 2.1.0
+4. Commit: "release: v2.1.0"
+5. Push to main
+6. Workflow runs → creates tag v2.1.0 + Release with changelog
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beasaavedra-psico",
   "type": "module",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/src/components/ui/NavMobile.astro
+++ b/src/components/ui/NavMobile.astro
@@ -3,6 +3,7 @@
 // Hamburger button + fullscreen slide-in overlay with nav links.
 import { t } from '../../i18n/utils';
 import { Icon } from 'astro-icon/components';
+import LangToggle from './LangToggle.astro';
 ---
 
 <!-- Hamburger trigger button -->
@@ -82,6 +83,11 @@ import { Icon } from 'astro-icon/components';
       data-nav-link
       class="nav-overlay-link text-2xl font-serif text-on-surface py-4 border-b border-outline-variant hover:text-primary transition-colors"
     >{t('nav.contact', 'ca')}</a>
+
+    <!-- Lang Toggle -->
+    <div class="py-6 flex justify-center">
+      <LangToggle />
+    </div>
 
     <!-- Book CTA -->
     <a

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import es from '../i18n/es.json';
 interface Props {
   title?: string;
   description?: string;
+  keywords?: string;
 }
 
 const {

--- a/src/pages/es.astro
+++ b/src/pages/es.astro
@@ -1,0 +1,16 @@
+---
+// src/pages/es.astro — legacy redirect from old /es URL
+// Switches to Spanish and redirects to home
+---
+<html lang="es">
+<head>
+  <meta http-equiv="refresh" content="0;url=/" />
+  <script is:inline>
+    localStorage.setItem('lang', 'es');
+    document.documentElement.lang = 'es';
+  </script>
+</head>
+<body>
+  <p>Redirecting...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add language toggle to mobile navigation (LangToggle in NavMobile.astro)
- Add /es redirect page that switches language and redirects to home
- Add automatic release workflow (.github/workflows/release.yml)
- Update AGENTS.md with release documentation
- Version bump: 2.0.1 → 2.1.0

## Changes
- `src/components/ui/NavMobile.astro` - Added LangToggle between nav links and CTA
- `src/pages/es.astro` - New redirect page
- `.github/workflows/release.yml` - Auto-creates tag and release on version change
- `AGENTS.md` - Added release workflow documentation

## Labels
- `feat` → New features (mobile lang toggle, /es redirect, auto-release)